### PR TITLE
Fixed errors when running “bin/magento setup:di:compile”

### DIFF
--- a/Controller/Addtocart/Index.php
+++ b/Controller/Addtocart/Index.php
@@ -16,9 +16,7 @@ class Index extends \Magento\Framework\App\Action\Action
      * @var \Magento\Framework\View\Result\PageFactory
      */
     protected $resultPageFactory;
-    protected $objectInterface;
     protected $productRepository;
-    protected $logger;
     protected $rejoinerHelper;
     protected $cart;
     protected $product;
@@ -29,7 +27,6 @@ class Index extends \Magento\Framework\App\Action\Action
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Framework\App\Action\Context $context
      * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
-     * @param \Magento\Framework\ObjectManagerInterface $objectInterface
      * @param \Magento\Checkout\Model\SessionFactory $session
      * @param \Magento\Checkout\Model\CartFactory $cart
      * @param \Magento\Catalog\Model\ProductFactory $product
@@ -39,18 +36,15 @@ class Index extends \Magento\Framework\App\Action\Action
         Session $checkoutSession,
         Context $context,
         PageFactory $resultPageFactory,
-        ObjectManagerInterface $objectInterface,
         SessionFactory $session,
         CartFactory $cart,
         ProductFactory $product
     ) {
         $this->rejoinerHelper    = $rejoinerHelper;
         $this->resultPageFactory = $resultPageFactory;
-        $this->objectInterface   = $objectInterface;
         $this->cart              = $cart;
         $this->session           = $session;
         $this->product           = $product;
-        $this->logger            = $objectInterface->get('\Psr\Log\LoggerInterface');
         parent::__construct($context);
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -35,9 +35,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /** @var \Magento\Checkout\Model\Session $_checkoutSession */
     protected $checkoutSession;
 
-    /** @var \Magento\Framework\UrlInterface $urlInterface */
-    protected $urlInterface;
-
     /** @var \Magento\Framework\ObjectManagerInterface $objectInterface*/
     protected $objectInterface;
 
@@ -57,7 +54,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * Data constructor.
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Framework\Session\SessionManager $sessionManager
-     * @param \Magento\Framework\UrlInterface $urlInterface
      * @param \Magento\Framework\HTTP\ZendClientFactory $httpClient
      * @param \Magento\Framework\ObjectManagerInterface $objectInterface
      * @param \Monolog\Logger $logger
@@ -66,7 +62,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function __construct(
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Framework\Session\SessionManager $sessionManager,
-        \Magento\Framework\UrlInterface $urlInterface,
         \Magento\Framework\HTTP\ZendClientFactory $httpClient,
         \Magento\Framework\ObjectManagerInterface $objectInterface,
         \Monolog\Logger $logger,
@@ -74,7 +69,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Framework\App\Helper\Context $context
     ) {
         $this->checkoutSession = $checkoutSession;
-        $this->urlInterface    = $urlInterface;
         $this->objectInterface = $objectInterface;
         $this->sessionManager  = $sessionManager;
         $this->_httpClient      = $httpClient;
@@ -109,7 +103,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $googleAttributesArray = $this->returnGoogleAttributes();
         $customAttributesArray = $this->returnCustomAttributes();
         $params = array_merge($product, $googleAttributesArray, $customAttributesArray);
-        $url = $this->urlInterface->getUrl('rejoiner/addtocart', [
+        $url = $this->_urlBuilder->getUrl('rejoiner/addtocart', [
             '_query'  => $params,
             '_secure' => true
         ]);


### PR DESCRIPTION
Removed extra code that caused errors during Generates DI configuration (see below)

Rejoiner\Acr\Controller\Addtocart\Index
Incorrect dependency in class Rejoiner\Acr\Controller\Addtocart\Index in /WebSites/orla-james/20161222102320-2a0b0a23/vendor/rejoiner/module-acr/Controller/Addtocart/Index.php
\Magento\Framework\ObjectManagerInterface already exists in context object
	
Rejoiner\Acr\Helper\Data
Incorrect dependency in class Rejoiner\Acr\Helper\Data in /WebSites/orla-james/20161222102320-2a0b0a23/vendor/rejoiner/module-acr/Helper/Data.php
\Magento\Framework\UrlInterface already exists in context object